### PR TITLE
カード登録のalertの修正

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -16,6 +16,7 @@ $(document).on('turbolinks:load', function(){
     Payjp.createToken(card, function(status, response) {
       if (response.error){
         $("#charge-form").prop('disabled', false);
+        alert("カード情報が正しくありません");
       } 
       else {
         $("#card_number").removeAttr("name");

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -9,5 +9,5 @@
     - exp_month = @default_card_information.exp_month.to_s
     - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
     = exp_month + " / " + exp_year
-    = form_with url: delete_cards_path, method: :post, id: 'charge-form', name: "inputForm", local: true do |f|
+    = form_with url: delete_cards_path, method: :post, id: 'delete-form', name: "inputForm", local: true do |f|
       = f.submit "削除する", class: 'card-delete-btn'


### PR DESCRIPTION
#What
カード登録の際のアラートの修正

#Why
カード登録のエラーの際に出るアラートがカード削除のときにも出てしまっていたので修正
